### PR TITLE
cups-browsed.service: Adapt to changes in cups

### DIFF
--- a/utils/cups-browsed.service
+++ b/utils/cups-browsed.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Make remote CUPS printers available locally
-Requires=cups.service
+Requires=org.cups.cupsd.service
 After=cups.service avahi-daemon.service
 Wants=avahi-daemon.service
 


### PR DESCRIPTION
CUPS seems to install org.cups.cupsd.service instead of cups.service now.